### PR TITLE
Add Dockerfile and other related files to enable container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.git
+**/.DS_Store
+**/node_modules
+Dockerfile
+docker-compose.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM golang:1 as builder
+ARG CGO_ENABLED=0\
+    GO_LDFLAGS="-s -w"
+RUN mkdir -p /tmp/build
+COPY . /tmp/build
+WORKDIR /tmp/build/cmd/gitdir
+RUN set -ex && ls -la && export &&\
+    until go get -v ./...; do sleep 1; done &&\
+    go build -o /tmp/gitdir -ldflags="$GO_LDFLAGS" -x -v &&\
+    chmod +x /tmp/gitdir
+
+FROM alpine:3 as runner
+ENV GITDIR_BASE_DIR=/var/gitdir\
+    GITDIR_BIND_ADDR=0.0.0.0:2222
+RUN until apk add --no-cache git curl openssh-keygen ca-certificates; do sleep 1; done &&\
+    update-ca-certificates
+RUN adduser -D -H -s /bin/false gitdir gitdir
+COPY --from=builder /tmp/gitdir /usr/bin/gitdir
+RUN chmod +x /usr/bin/gitdir && ls -l /usr/bin/gitdir
+RUN rm -rf /{tmp,var,opt}/*
+RUN mkdir -p $GITDIR_BASE_DIR && chown -R gitdir:gitdir $GITDIR_BASE_DIR
+RUN echo -e '#!/bin/sh\n \
+( \
+set -x; \
+rm -rf $GITDIR_BASE_DIR/admin/unbared; \
+until [ -d "$GITDIR_BASE_DIR/admin/admin.git" ]; do echo "The admin repo is not ready"; sleep 1; done &&\
+cd $GITDIR_BASE_DIR/admin/admin.git &&\
+until git log >> /dev/null 2>&1; do echo "The admin repo is been initalized, waiting"; sleep 5; done; \
+mv $GITDIR_BASE_DIR/admin/admin.git/hooks $GITDIR_BASE_DIR/admin/admin.git/hooks.disabled &&\
+git clone $GITDIR_BASE_DIR/admin/admin.git $GITDIR_BASE_DIR/admin/unbared &&\
+cd $GITDIR_BASE_DIR/admin/unbared &&\
+git config user.name "gitdir Docker Helper Script" &&\
+git config user.email "gitdir@gitdir.nosuchtld" &&\
+vi config.yml &&\
+git commit --no-verify config.yml &&\
+git push &&\
+rm -rf $GITDIR_BASE_DIR/admin/unbared &&\
+echo "Saved! You may need to restart the server to verify and apply the settings"; \
+mv $GITDIR_BASE_DIR/admin/admin.git/hooks.disabled $GITDIR_BASE_DIR/admin/admin.git/hooks \
+)' > /usr/bin/gitdir_config && chmod +x /usr/bin/gitdir_config
+WORKDIR $GITDIR_BASE_DIR
+USER gitdir:gitdir
+
+EXPOSE 2222
+ENTRYPOINT ["gitdir"]
+CMD []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,59 @@
+# Build and deploy steps:
+#
+# 01. On the host machine, run
+#     `RUID=gitdir RGID=gitdir docker-compose --compatibility build gitdir`
+# 02. Then `docker volume create gitdir`
+# 03. Follow by `RUID=gitdir RGID=gitdir docker-compose --compatibility up -d`,
+#     a container named `gitdir` should start
+# 04. If this is the first time you deploy `gitdir` in this method, run
+#     `docker exec -it gitdir gitdir_config` to initialize it
+# 05. Command `gitdir_config` will wait for `gitdir` to load, this may take
+#     few minutes. You can checkout `docker logs gitdir` for the progress (the
+#     wait usually ends when "Starting SSH server" is logged)
+# 06. After `gitdir` is loaded, `gitdir_config` will automatically open
+#     `config.yml` for you to edit. Make sure to add yourself as the admin by
+#     creating an new item under `users`, for example:
+#     users:
+#       <username,replacewithyourown>:
+#         is_admin: true
+#         disabled: false
+#         keys:
+#           - <Your SSH public key, the one in ~/.ssh/id_ed25519.pub for example>
+#     Watch out for the format, Use SPACE instead of tab so the yaml file
+#     remain valid.
+#     Save the file by pressing ESC and then type :wq
+# 07. Create commit information, and then ESC + :wq as above
+# 08. If you see "Saved!" message, run `docker restart gitdir` to restart
+#     `gitdir`. Otherwise, please checkout the output to see what wrong, and
+#     maybe try step 6 again
+# 09. After `gitdir` restarts, you may try
+#     `git clone ssh://<your_username>@<gitdir_host>:2222/admin.git`
+#     to clone the admin repository of gitdir
+# 10. To learn how to create repository and more, see the home page of `gitdir`
+#
+# Note: RGID and RUID defines which user `gitdir` will be run under. Checkout
+#       related Docker documentation for detail
+version: "3.7"
+
+volumes:
+  gitdir:
+    external: true
+
+services:
+  gitdir:
+    image: gitdir-localbuilt
+    container_name: gitdir
+    user: "${RUID}:${RGID}"
+    build: .
+    restart: unless-stopped
+    ports:
+      - "0.0.0.0:2222:2222/tcp"
+    stdin_open: true
+    volumes:
+      - gitdir:/var/gitdir
+    tty: true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 256M


### PR DESCRIPTION
This Pull Requests adds `Dockerfile`, `docker-compose.yaml` and `.dockerignore` for `gitdir`, allowing the project to be deployed as a Docker container.

I personally tested the files and the build process without issue. Tested platforms: AMD64 and ARM32v7.

However, these file are still experimental, if you're interested, please give it a try and send feedback.

My main worry is about a little script called `gitdir_config` that I embeded into the image. The script is intended to help first-timers to initialize `gitdir` during their first run. However, the script is little hacky, I'm not sure I did what should've been done. So please give it a look.

Thanks!